### PR TITLE
Ci version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+.vscode

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -23,7 +23,7 @@
 
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       env: WP_VERSION=latest
     - php: 7.3
       env: WP_VERSION=latest
-    # Because now PHP 7.2 is in the Active Support period and should be focused in development.
+    # Because now PHP 7.3 is in the Active Support period and should be focused in development.
     # @see https://www.php.net/supported-versions.php
     - php: 7.3
       env: WP_VERSION=trunk

--- a/tests/includes/controllers/test-class-static-press-ajax-init.php
+++ b/tests/includes/controllers/test-class-static-press-ajax-init.php
@@ -34,6 +34,7 @@ class Static_Press_Ajax_Init_Test extends \WP_UnitTestCase {
 	 * Function get_urls() should return urls of front page, static files, and SEO.
 	 * 
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_process_ajax_request_trancate() {
 		Repository_For_Test::insert_url(

--- a/tests/includes/controllers/test-class-static-press-ajax-processor.php
+++ b/tests/includes/controllers/test-class-static-press-ajax-processor.php
@@ -42,6 +42,7 @@ class Static_Press_Ajax_Processor_Test extends \WP_UnitTestCase {
 	 * Function json_output() should die.
 	 * 
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_json_output() {
 		$argument     = array(

--- a/tests/includes/test-class-static-press-database.php
+++ b/tests/includes/test-class-static-press-database.php
@@ -110,6 +110,7 @@ class Static_Press_Database_Test extends \WP_UnitTestCase {
 	 * Function ajax_fetch() should fail when record doesn't exist.
 	 * 
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_ajax_fetch_without_record() {
 		$this->sign_on_to_word_press();
@@ -131,6 +132,7 @@ class Static_Press_Database_Test extends \WP_UnitTestCase {
 	 * @param Model_Url[] $array_record Array record.
 	 * @param string      $expect       Expect return value.
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_ajax_fetch_with_record( $array_record, $expect ) {
 		$this->sign_on_to_word_press();
@@ -289,6 +291,7 @@ class Static_Press_Database_Test extends \WP_UnitTestCase {
 	 * Function ajax_finalyze() should response result.
 	 * 
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_ajax_finalyze() {
 		$user_id = $this->sign_on_to_word_press();
@@ -303,6 +306,7 @@ class Static_Press_Database_Test extends \WP_UnitTestCase {
 	 * Function ajax_init() should response record count per file type.
 	 * 
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_all() {
 		$resource_file_name = 'white.png';

--- a/tests/testlibraries/ajax_invokers/class-ajax-fetch-invoker.php
+++ b/tests/testlibraries/ajax_invokers/class-ajax-fetch-invoker.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Ajax_Fetch_Invoker
+ *
+ * @package static_press\tests\testlibraries\ajax_invokers
+ */
+
+namespace static_press\tests\testlibraries\ajax_invokers;
+
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/ajax_invokers/class-ajax-invoker.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/creators/class-mock-creator.php';
+use static_press\tests\testlibraries\ajax_invokers\Ajax_Invoker;
+use static_press\tests\testlibraries\creators\Mock_Creator;
+/**
+ * Class Ajax_Fetch_Invoker
+ */
+class Ajax_Fetch_Invoker extends Ajax_Invoker {
+	/**
+	 * Invokes ajax function.
+	 */
+	protected function invoke_ajax() {
+		$this->static_press->ajax_fetch( Mock_Creator::create_terminator_mock() );
+	}
+}

--- a/tests/testlibraries/ajax_invokers/class-ajax-finalyze-invoker.php
+++ b/tests/testlibraries/ajax_invokers/class-ajax-finalyze-invoker.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Ajax_Finalyze_Invoker
+ *
+ * @package static_press\tests\testlibraries\ajax_invokers
+ */
+
+namespace static_press\tests\testlibraries\ajax_invokers;
+
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/ajax_invokers/class-ajax-invoker.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/creators/class-mock-creator.php';
+use static_press\tests\testlibraries\ajax_invokers\Ajax_Invoker;
+use static_press\tests\testlibraries\creators\Mock_Creator;
+/**
+ * Class Ajax_Finalyze_Invoker
+ */
+class Ajax_Finalyze_Invoker extends Ajax_Invoker {
+	/**
+	 * Invokes ajax function.
+	 */
+	protected function invoke_ajax() {
+		$this->static_press->ajax_finalyze( Mock_Creator::create_terminator_mock() );
+	}
+}

--- a/tests/testlibraries/ajax_invokers/class-ajax-init-invoker.php
+++ b/tests/testlibraries/ajax_invokers/class-ajax-init-invoker.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Ajax_Init_Invoker
+ *
+ * @package static_press\tests\testlibraries\ajax_invokers
+ */
+
+namespace static_press\tests\testlibraries\ajax_invokers;
+
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/ajax_invokers/class-ajax-invoker.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/creators/class-mock-creator.php';
+use static_press\tests\testlibraries\ajax_invokers\Ajax_Invoker;
+use static_press\tests\testlibraries\creators\Mock_Creator;
+/**
+ * Class Ajax_Init_Invoker
+ */
+class Ajax_Init_Invoker extends Ajax_Invoker {
+	/**
+	 * Invokes ajax function.
+	 */
+	protected function invoke_ajax() {
+		$this->static_press->ajax_init( Mock_Creator::create_terminator_mock() );
+	}
+}

--- a/tests/testlibraries/ajax_invokers/class-ajax-invoker.php
+++ b/tests/testlibraries/ajax_invokers/class-ajax-invoker.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Ajax_Invoker
+ *
+ * @package static_press\tests\testlibraries\ajax_invokers
+ */
+
+namespace static_press\tests\testlibraries\ajax_invokers;
+
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/exceptions/class-die-exception.php';
+use static_press\tests\testlibraries\exceptions\Die_Exception;
+
+/**
+ * Class Ajax_Invoker
+ */
+abstract class Ajax_Invoker {
+	/**
+	 * ExpectUrl constructor.
+	 *
+	 * @param PHPUnit_Framework_TestCase $test_case    Expect type of URL object.
+	 * @param Static_Press               $static_press StaticPress.
+	 */
+	public function __construct( $test_case, $static_press ) {
+		$this->test_case    = $test_case;
+		$this->static_press = $static_press;
+	}
+
+	/**
+	 * Requests.
+	 * 
+	 * @return array JSON responce.
+	 */
+	public function request() {
+		ob_start();
+		try {
+			$this->invoke_ajax();
+		} catch ( Die_Exception $exception ) {
+			$output = ob_get_clean();
+			$this->test_case->assertEquals( 'Dead!', $exception->getMessage() );
+			return json_decode( $output, true );
+		}
+		$this->test_case->fail();
+	}
+
+	/**
+	 * Invokes ajax function.
+	 */
+	abstract protected function invoke_ajax();
+}

--- a/tests/testlibraries/class-error-handler.php
+++ b/tests/testlibraries/class-error-handler.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Class Error_Handler
+ *
+ * @package static_press\tests\testlibraries
+ */
+
+namespace static_press\tests\testlibraries;
+
+/**
+ * Error handler.
+ */
+class Error_Handler {
+	/**
+	 * Handles error.
+	 * 
+	 * @param int    $errno      The first parameter, errno, contains the level of the error raised, as an integer.
+	 * @param string $errstr     The second parameter, errstr, contains the error message, as a string.
+	 * @param string $errfile    The third parameter is optional, errfile, which contains the filename that the error was raised in, as a string.
+	 * @param int    $errline    The fourth parameter is optional, errline, which contains the line number the error was raised at, as an integer.
+	 * @param array  $errcontext The fifth parameter is optional, errcontext, which is an array that points to the active symbol table at the point the error occurred.
+	 *                           In other words, errcontext will contain an array of every variable that existed in the scope the error was triggered in.
+	 *                           User error handler must not modify error context.
+	 * @return false
+	 * @throws \LogicException When error.
+	 */
+	public function handle( $errno, $errstr, $errfile, $errline, $errcontext ) {
+		// error was suppressed with the @-operator.
+		if ( 0 === error_reporting() ) {
+			return false;
+		}
+		throw new \LogicException( $errstr, $errno );
+	}
+}

--- a/tests/testlibraries/creators/class-model-url-creator.php
+++ b/tests/testlibraries/creators/class-model-url-creator.php
@@ -10,6 +10,7 @@ namespace static_press\tests\testlibraries\creators;
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/creators/class-mock-creator.php';
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/class-expect-urls-static-files.php';
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/repositories/class-repository-for-test.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/class-error-handler.php';
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/class-model-url.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\models\Static_Press_Model_Url_Author;
@@ -20,6 +21,7 @@ use static_press\includes\models\Static_Press_Model_Url_Single;
 use static_press\includes\models\Static_Press_Model_Url_Static_File;
 use static_press\includes\models\Static_Press_Model_Url_Term;
 use static_press\tests\testlibraries\creators\Mock_Creator;
+use static_press\tests\testlibraries\Error_Handler;
 use static_press\tests\testlibraries\Expect_Urls_Static_Files;
 use static_press\tests\testlibraries\Model_Url;
 use static_press\tests\testlibraries\repositories\Repository_For_Test;
@@ -127,15 +129,8 @@ class Model_Url_Creator {
 		 * 
 		 * @see https://stackoverflow.com/questions/1241728/can-i-try-catch-a-warning/1241751#1241751
 		 */
-		set_error_handler(
-			function( $errno, $errstr, $errfile, $errline, $errcontext ) {
-				// error was suppressed with the @-operator.
-				if ( 0 === error_reporting() ) {
-					return false;
-				}
-				throw new \LogicException( $errstr, $errno );
-			}
-		);
+		$error_handler = new Error_Handler();
+		set_error_handler( array( $error_handler, 'handle' ) );
 		$expect                = array();
 		$array_logic_exception = array();
 		foreach ( Expect_Urls_Static_Files::EXPECT_URLS as $expect_url ) {


### PR DESCRIPTION
- Fix PHP testVersion from 5.4 to 5.6
- Fix comment
- Remove anonymous function
  Since PHP cannot serialize anonymous functions.
  
  @see https://core.trac.wordpress.org/ticket/50482
  @see https://github.com/sebastianbergmann/phpunit/issues/2739

- Add annotation to disable preserve global state
  This is temporary avoidance measure.
  Since WordPress 5.5 cause
  Uncaught Exception: Serialization of 'Closure' is not allowed
  when run PHPUnit in plugin development.
  
  @see https://core.trac.wordpress.org/ticket/50482#comment:7

- Add IDE settings into .gitignore entry