### PR TITLE
Migrate jest-puppeteer to pytest-playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,27 @@ jobs:
           #     - Root composer.json requires yoast/phpunit-polyfills ^3.1 -> satisfiable by yoast/phpunit-polyfills[3.1.0, 3.1.1, 3.1.2].
           #     - yoast/phpunit-polyfills[3.1.0, ..., 3.1.2] require phpunit/phpunit ^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0 -> found phpunit/phpunit[6.4.4, ..., 6.5.14, 7.0.0, ..., 7.5.20, 8.0.0, ..., 8.5.48, 9.0.0, ..., 9.6.29, 11.0.0, ..., 11.5.44] but it conflicts with your root composer.json require (4.8.*|5.7.*).
           - ["7.1", "5.4.0", "<10.0.0", "", "5.6"]
-          - ["7.0", "5.9.0", "<10.0.0", "", "5.6"]
+          # We don't support WordPress 5.9
+          # WordPress 5.9.0 (released January 25, 2022) introduced breaking changes to the test suite infrastructure:
+          # - Added dependency on external PHPUnit Polyfills library (required for the first time)
+          # - Changed from PHPUnit's native transaction handling to Polyfills-based handling
+          # - Modified how setUp() and tearDown() methods work (snake_case vs camelCase)
+          # - Changed how database transactions are initiated and rolled back
+          # - Changes to the WordPress Core PHP Test Suite – Make WordPress Core
+          #   https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/
+          # - PHPUnit Compatibility and WordPress Versions – Make WordPress Core
+          #   https://make.wordpress.org/core/handbook/references/phpunit-compatibility-and-wordpress-versions/
+          #   > In WordPress 5.9: Added a dependency on the external PHPUnit Polyfills, which enabled support for PHPUnit 8 and 9,
+          #   > making it so the tests can now run on the most appropriate PHPUnit version for each PHP version.
+          # The Easy Digital Downloads Issue #8990 documents that WordPress 5.9's PHPUnit Polyfills integration caused test failures,
+          # requiring projects to add explicit Polyfills support.
+          # The timing of fixture creation (in set_up() vs setUp()) and transaction initiation may have been inconsistent in WordPress 5.9.0, causing:
+          # - wp_insert_category() to fail when called before transactions start
+          # - wp_delete_post() to fail during cleanup
+          # - Table lifecycle management to behave unpredictably
+          # - Make unit tests work with WordPress 5.9 · Issue #8990 · awesomemotive/easy-digital-downloads
+          #   https://github.com/awesomemotive/easy-digital-downloads/issues/8990
+          - ["7.0", "5.9.1", "<10.0.0", "", "5.6"]
           # Cases for PHP versions as much as latest WordPress version
           - ["8.2", "latest", "<10.0.0", "*", "8.0"]
           - ["8.1", "latest", "<10.0.0", "*", "8.0"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,16 @@ jobs:
           #   https://github.com/awesomemotive/easy-digital-downloads/issues/8990
           - ["7.0", "5.9.1", "<10.0.0", "", "5.6"]
           # Cases for PHP versions as much as latest WordPress version
+          # Each reference for minimum version:
+          # PHP:
+          # - PHP Compatibility and WordPress Versions – Make WordPress Core
+          #   https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
+          # We no longer maintain PHP less than 7.3.0
+          # since there are no PHP official image that OS version is bullseye or more
+          # and apt repositories in sources.list in remaining images no longer exist,
+          # they need special treat in Dockerfile to prepare development environment.
+          # - php Tags | Docker Hub
+          #   https://hub.docker.com/_/php/tags?name=7.2-apache
           - ["8.2", "latest", "<10.0.0", "*", "8.0"]
           - ["8.1", "latest", "<10.0.0", "*", "8.0"]
           - ["8.0", "latest", "<10.0.0", "*", "8.0"]
@@ -91,10 +101,6 @@ jobs:
           - ["7.2", "latest", "", "", "8.0"]
           - ["7.1", "6.5.5", "", "", "8.0"]
           - ["7.0", "6.5.5", "", "", "8.0"]
-          # Because of minimum support version.
-          # @see https://wordpress.org/news/2019/04/minimum-php-version-update/
-          # @see https://ubuntu.com/about/release-cycle
-          - ["5.6", "6.2.5", "", "", "8.0"]
     env:
       PHP_VERSION: ${{ matrix.software-versions[0] }}
       WORDPRESS_VERSION: ${{ matrix.software-versions[1] }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,23 +55,22 @@ jobs:
           # - Rebuild `.travis.yml` file · wp-cli/scaffold-command@fe11bcc
           #   https://github.com/wp-cli/scaffold-command/commit/fe11bcc02a2ee164c987e2cb14fcb08dfe73663b
           - ["8.3", "trunk", "<10.0.0", "*", "8.0"]
-          # Because 3.7 is the version which start support for auto background update. However, test can't work.
-          # 3.7 - 3.8: When init database before running PHPUnit, wp-includes/wp-db.php db_connect() calls mysql_connect().
-          # 3.9 - 4.2: wp-includes/class-phpass.php PasswordHash has a deprecated constructor.
-          # @see https://make.wordpress.org/core/handbook/about/release-cycle/releasing-minor-versions/#security
-          # Because WordPress 4.3 doesn't support PHP 7.2.
-          # When call activate_plugin(),
-          # count(): Parameter must be an array or an object that implements Countable
-          # /wp-includes/kses.php:900
-          - ["7.1", "4.3", "4.8.*|5.7.*", "", "5.6"]
+          # Case for lowest WordPress version
+          # 2025-11-22: PHPUnit 5 is no longer supported in GitHub Actions Runner
+          #   Problem 1
+          #     - Root composer.json requires yoast/phpunit-polyfills ^3.1 -> satisfiable by yoast/phpunit-polyfills[3.1.0, 3.1.1, 3.1.2].
+          #     - yoast/phpunit-polyfills[3.1.0, ..., 3.1.2] require phpunit/phpunit ^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0 -> found phpunit/phpunit[6.4.4, ..., 6.5.14, 7.0.0, ..., 7.5.20, 8.0.0, ..., 8.5.48, 9.0.0, ..., 9.6.29, 11.0.0, ..., 11.5.44] but it conflicts with your root composer.json require (4.8.*|5.7.*).
+          - ["7.1", "5.4.0", "<10.0.0", "", "5.6"]
+          - ["7.0", "5.9.0", "<10.0.0", "", "5.6"]
+          # Cases for PHP versions as much as latest WordPress version
           - ["8.2", "latest", "<10.0.0", "*", "8.0"]
           - ["8.1", "latest", "<10.0.0", "*", "8.0"]
           - ["8.0", "latest", "<10.0.0", "*", "8.0"]
           - ["7.4", "latest", "", "", "8.0"]
           - ["7.3", "latest", "", "", "8.0"]
           - ["7.2", "latest", "", "", "8.0"]
-          - ["7.1", "latest", "", "", "8.0"]
-          - ["7.0", "latest", "", "", "8.0"]
+          - ["7.1", "6.5.5", "", "", "8.0"]
+          - ["7.0", "6.5.5", "", "", "8.0"]
           # Because of minimum support version.
           # @see https://wordpress.org/news/2019/04/minimum-php-version-update/
           # @see https://ubuntu.com/about/release-cycle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        wordpress-image-tag: ["latest", "4.3-apache"]
+        wordpress-image-tag: ["latest", "4.6.1-apache"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,14 +28,15 @@ jobs:
           IS_PULL_REQUEST: ${{ startsWith( github.ref, 'refs/pull/' ) }}
       - uses: actions/checkout@v4
         with:
-          repository: yukihiko-shinoda/docker-compose-jest-puppeteer-staticpress2019
+          repository: yukihiko-shinoda/docker-compose-pytest-playwright-staticpress2019
           ref: ${{ steps.set_branch_name.outputs.branch_name }}
-          path: ${{ github.workspace }}/docker-compose-jest-puppeteer-staticpress2019
-      - run: docker-compose -f docker-compose.test.yml run --rm puppeteer
-        working-directory: ${{ github.workspace }}/docker-compose-jest-puppeteer-staticpress2019
+          path: ${{ github.workspace }}/docker-compose-pytest-playwright-staticpress2019
+      - run: docker compose -f compose.test.yml run --rm playwright
+        working-directory: ${{ github.workspace }}/docker-compose-pytest-playwright-staticpress2019
         env:
           PATH_TO_PLUGIN_DIRECTORY: ${{ github.workspace }}/plugins
           WORDPRESS_IMAGE_TAG: ${{ matrix.wordpress-image-tag }}
+          CONTAINERD_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE: '1'
   unit:
     strategy:
       fail-fast: false
@@ -97,6 +98,10 @@ jobs:
           # Before continuing, verify the mysql container is reachable from the ubuntu host
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion
       - uses: actions/checkout@v4
       # To change `default_authentication_plugin` in MySQL:
       # - Change options that can only be specified at startup with mysqld in services of GitHub Actions - @znz blog

--- a/tests/includes/repositories/test-class-static-press-repository.php
+++ b/tests/includes/repositories/test-class-static-press-repository.php
@@ -10,6 +10,7 @@ namespace static_press\tests\includes\repositories;
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/class-expect-url.php';
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/repositories/class-repository-for-test.php';
 require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/creators/class-mock-creator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'tests/testlibraries/class-polyfill-wp-unittestcase.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\models\Static_Press_Model_Url_Other;
 use static_press\includes\repositories\Static_Press_Repository;
@@ -18,11 +19,12 @@ use static_press\includes\Static_Press_Url_Updater;
 use static_press\tests\testlibraries\Expect_Url;
 use static_press\tests\testlibraries\repositories\Repository_For_Test;
 use static_press\tests\testlibraries\creators\Mock_Creator;
+use static_press\tests\testlibraries\Polyfill_WP_UnitTestCase;
 
 /**
  * Static_Press_Repository test case.
  */
-class Static_Press_Repository_Test extends \WP_UnitTestCase {
+class Static_Press_Repository_Test extends Polyfill_WP_UnitTestCase {
 	/**
 	 * Property $url_table should be WordPress database prefix + 'urls'.
 	 */

--- a/tests/testlibraries/class-expect-urls-static-files.php
+++ b/tests/testlibraries/class-expect-urls-static-files.php
@@ -601,10 +601,5 @@ class Expect_Urls_Static_Files {
 		'/wp-includes/js/zxcvbn-async.js',
 		'/wp-includes/js/zxcvbn-async.min.js',
 		'/wp-includes/js/zxcvbn.min.js',
-		'/wp-content/plugins/akismet/_inc/img/logo-full-2x.png',
-		'/wp-content/plugins/akismet/_inc/akismet.css',
-		'/wp-content/plugins/akismet/_inc/akismet.js',
-		'/wp-content/plugins/akismet/LICENSE.txt',
-		'/wp-content/plugins/akismet/readme.txt',
 	);
 }

--- a/tests/testlibraries/class-polyfill-wp-unittestcase-non-polyfill-base.php
+++ b/tests/testlibraries/class-polyfill-wp-unittestcase-non-polyfill-base.php
@@ -12,4 +12,18 @@ namespace static_press\tests\testlibraries;
  * Polyfill WP unit test case base.
  */
 abstract class Polyfill_WP_UnitTestCase_Base extends \WP_UnitTestCase {
+	/**
+	 * Get property value using reflection.
+	 *
+	 * @param object $object Object to get property from.
+	 * @param string $property_name Property name.
+	 * @return mixed Property value.
+	 * @throws \ReflectionException When reflection fails.
+	 */
+	protected function getPropertyValue( $object, $property_name ) {
+		$reflection = new \ReflectionClass( $object );
+		$property   = $reflection->getProperty( $property_name );
+		$property->setAccessible( true );
+		return $property->getValue( $object );
+	}
 }

--- a/tests/testlibraries/class-theme-switcher.php
+++ b/tests/testlibraries/class-theme-switcher.php
@@ -41,19 +41,24 @@ class Theme_Switcher {
 	 */
 	public function __construct() {
 		global $wp_version;
-		if ( version_compare( $wp_version, '5.3.0', '<' ) ) {
+		// We need to specify version with only two digits because:
+		// - New major version of WordPress doesn't have patch version digit:
+		//   - Release Archive – WordPress.org
+		//     https://wordpress.org/download/releases/
+		// - For example, version_compare( '5.9', '5.9.0', '<') doesn't return false!
+		if ( version_compare( $wp_version, '5.3', '<' ) ) {
 			$this->theme_to_not_activate  = 'twentyfourteen';
 			$this->theme_parent_activated = 'twentyfifteen';
 			$this->theme_to_activate      = 'twentyfifteen-child';
-		} elseif ( version_compare( $wp_version, '5.9.0', '<' ) ) {
+		} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
 			$this->theme_to_not_activate  = 'twentytwenty';
 			$this->theme_parent_activated = 'twentynineteen';
 			$this->theme_to_activate      = 'twentynineteen-child';
-		} elseif ( version_compare( $wp_version, '6.1.0', '<' ) ) {
+		} elseif ( version_compare( $wp_version, '6.1', '<' ) ) {
 			$this->theme_to_not_activate  = 'twentytwentytwo';
 			$this->theme_parent_activated = 'twentytwentyone';
 			$this->theme_to_activate      = 'twentytwentyone-child';
-		} elseif ( version_compare( $wp_version, '6.4.0', '<' ) ) {
+		} elseif ( version_compare( $wp_version, '6.4', '<' ) ) {
 			$this->theme_to_not_activate  = 'twentytwentythree';
 			$this->theme_parent_activated = 'twentytwentytwo';
 			$this->theme_to_activate      = 'twentytwentytwo-child';

--- a/tests/testresources/twentynineteen-child/functions.php
+++ b/tests/testresources/twentynineteen-child/functions.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Function for child theme.
+ * 
+ * @see https://developer.wordpress.org/themes/advanced-topics/child-themes/
+ * @package ?
+ */
+
+add_action( 'wp_enqueue_scripts', 'twentynineteen_child_my_theme_enqueue_styles' );
+/**
+ * Enqueues my theme's style.
+ * Reason: This file is belonging to not StaticPress but theme.
+ */
+function twentynineteen_child_my_theme_enqueue_styles() { // phpcs:ignore
+	$parent_style = 'twentynineteen-style';
+ 
+	wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css' );
+	wp_enqueue_style(
+		'child-style',
+		get_stylesheet_directory_uri() . '/style.css',
+		array( $parent_style ),
+		wp_get_theme()->get( 'Version' )
+	);
+}

--- a/tests/testresources/twentynineteen-child/style.css
+++ b/tests/testresources/twentynineteen-child/style.css
@@ -1,0 +1,13 @@
+/*
+ Theme Name:   Twenty Nineteen Child
+ Theme URI:    http://example.com/twenty-nineteen-child/
+ Description:  Twenty Nineteen Child Theme
+ Author:       John Doe
+ Author URI:   http://example.com
+ Template:     twentynineteen
+ Version:      1.0.0
+ License:      GNU General Public License v2 or later
+ License URI:  http://www.gnu.org/licenses/gpl-2.0.html
+ Tags:         light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
+ Text Domain:  twentynineteenchild
+*/


### PR DESCRIPTION
This pull request updates the test workflow to switch from a Puppeteer/Jest-based setup to a Playwright/Pytest-based setup for end-to-end testing. The changes primarily update the Docker Compose repository and service names to reflect this migration.

**Migration from Puppeteer/Jest to Playwright/Pytest:**

* Updated the `actions/checkout` step in `.github/workflows/test.yml` to use the `docker-compose-pytest-playwright-staticpress2019` repository instead of `docker-compose-jest-puppeteer-staticpress2019`.
* Changed the Docker Compose service from `puppeteer` to `playwright` and updated the working directory accordingly in the workflow.