### PR TITLE
Rename default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # 🗽StaticPress2019🗿
 
-[![Test](https://github.com/yukihiko-shinoda/staticpress2019/workflows/Test/badge.svg)](https://github.com/yukihiko-shinoda/staticpress2019/actions?query=workflow%3ATest)
-[![Build Status](https://app.travis-ci.com/yukihiko-shinoda/staticpress2019.svg?branch=master)](https://app.travis-ci.com/yukihiko-shinoda/staticpress2019)
+[![Test](https://github.com/yukihiko-shinoda/staticpress2019/actions/workflows/test.yml/badge.svg)](https://github.com/yukihiko-shinoda/staticpress2019/actions?query=branch%3Amain)
 [![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/staticpress2019)](https://wordpress.org/plugins/staticpress2019/)
-[![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/staticpress2019)](https://app.travis-ci.com/yukihiko-shinoda/staticpress2019)
-[![PHP from Travis config](https://img.shields.io/travis/php-v/yukihiko-shinoda/staticpress2019/master)](https://app.travis-ci.com/yukihiko-shinoda/staticpress2019)
-[![WordPress Plugin: Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/staticpress2019)](https://app.travis-ci.com/yukihiko-shinoda/staticpress2019)
+[![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/staticpress2019)](https://github.com/yukihiko-shinoda/staticpress2019/actions?query=branch%3Amain)
+[![WordPress Plugin: Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/staticpress2019)](https://github.com/yukihiko-shinoda/staticpress2019/actions?query=branch%3Amain)
 [![WordPress Plugin Active Installs](https://img.shields.io/wordpress/plugin/installs/staticpress2019)](https://wordpress.org/plugins/staticpress2019/advanced/)
 [![WordPress Plugin Downloads](https://img.shields.io/wordpress/plugin/dm/staticpress2019)](https://wordpress.org/plugins/staticpress2019/advanced/)
-[![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fyukihiko-shinoda%2Fstaticpress2019)](http://twitter.com/share?text=StaticPress2019&url=https://github.com/yukihiko-shinoda/staticpress2019&hashtags=staticpress)
+[![X URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fyukihiko-shinoda%2Fstaticpress2019)](https://x.com/intent/post?text=StaticPress2019&url=https%3A%2F%2Fgithub.com%2Fyukihiko-shinoda%2Fstaticpress2019&hashtags=staticpress)
 
 Transforms your WordPress into static websites and blogs.
 


### PR DESCRIPTION
This pull request updates the project to reflect the change from the `master` branch to the `main` branch and modernizes the status badges in the `README.md`. The workflow configuration and badge links are updated to ensure consistency and accuracy with the current branch naming and CI/CD practices.

Branch and workflow updates:
* Changed references from `master` to `main` in the `.github/workflows/test.yml` configuration to ensure CI runs on the correct branch.

Documentation and badge improvements:
* Updated status badges in `README.md` to reference the new `main` branch and GitHub Actions URLs instead of Travis CI, ensuring they display accurate build and test status.
* Updated the social badge from "Twitter" to "X" with a new sharing URL in the `README.md`.