### PR TITLE
Bump yukihiko-shinoda/action-deploy-wordpress-plugin from 2.1.1 to 2.3.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Deploy
-        uses: yukihiko-shinoda/action-deploy-wordpress-plugin@v2.1.1
+        uses: yukihiko-shinoda/action-deploy-wordpress-plugin@v2.3.0
         env:
           SVN_REPOSITORY_URL: ${{ secrets.SvnRepositoryUrl }}
           SVN_USER_NAME: ${{ secrets.SvnUserName }}


### PR DESCRIPTION
This pull request updates the deployment workflow to use a newer version of the WordPress plugin deployment action. This ensures that the latest features and fixes from the action are included in our deployment process.

Deployment workflow update:

* Updated the `yukihiko-shinoda/action-deploy-wordpress-plugin` action from version `v2.1.1` to `v2.3.0` in the `.github/workflows/deploy.yml` file.